### PR TITLE
is_negatively_weighted, docstrings, empty graph

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -120,6 +120,9 @@ New functionalities
   Added function for computing quotient graphs; also created a new module,
   ``networkx.algorithms.minors``.
 
+* [`#1438 <https://github.com/networkx/networkx/pull/1438>`_]
+  Added longest_path and longest_path_length for DAG.
+
 * [`#1445 <https://github.com/networkx/networkx/pull/1448>`_]
   Added a new modularity matrix module to ``networkx.linalg``,
   and associated spectrum functions to the ``networkx.linalg.spectrum``
@@ -138,8 +141,10 @@ New functionalities
   Adds ``triadic_census`` function; also creates a new module,
   :mod:`networkx.algorithms.triads`.
 
-* [`#1438 <https://github.com/networkx/networkx/pull/1438>`_]
-  Added longest_path and longest_path_length for DAG.
+* [`#1476 <https://github.com/networkx/networkx/pull/1476>`_]
+  Adds functions for testing if a graph has weighted or negatively weighted
+  edges. Also adds a function for testing if a graph is empty. These are
+  ``is_weighted``, ``is_negatively_weighted``, and ``is_empty``.
 
 Removed functionalities
 -----------------------

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -650,5 +650,5 @@ def negative_weights(G, edge=None, weight='weight'):
         for u, v, w in G.edges(data=True):
             if weight in w:
                 if w[weight] < 0:
-                    negative = True
+                    return True
     return negative

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -589,10 +589,7 @@ def is_weighted(G, edge=None, weight='weight'):
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
         return weight in attr
-    for u, v, w in G.edges(data=True):
-        if weight not in w:
-            return False
-    return True
+    return all(weight in w for u, v, w in G.edges(data=True))
 
 
 def negative_weights(G, edge=None, weight='weight'):
@@ -636,7 +633,6 @@ def negative_weights(G, edge=None, weight='weight'):
     >>> print(nx.negative_weights(G))
     True
     """
-    negative = False
     if edge is not None:
         attr = G.get_edge_data(*edge)
         if attr is None:
@@ -649,4 +645,4 @@ def negative_weights(G, edge=None, weight='weight'):
             if weight in w:
                 if w[weight] < 0:
                     return True
-    return negative
+    return False

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -610,7 +610,7 @@ def negative_weights(G, edge=None, weight='weight'):
         Checks for a specific edge if it is negatively weighted (not None) or for all
         edges in graph (None) (if one of them is negatively weighted)
 
-    weight: string, optional (default=None)
+    weight: string, optional (default='weight')
         Edge data key corresponding to the edge weight.
 
     Returns

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -638,5 +638,4 @@ def negative_weights(G, edge=None, weight='weight'):
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
         return weight in attr and attr[weight] < 0
-    else:
-        return any(weight in w and w[weight] < 0 for u, v, w in G.edges(data=True))
+    return any(weight in w and w[weight] < 0 for u, v, w in G.edges(data=True))

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -597,7 +597,7 @@ def weighted_edges(G, edge=None, weight='weight'):
         return weighted
 
 
-def negative_weights(G, edge=None):
+def negative_weights(G, edge=None, weight='weight'):
     """Check if the graph has a negatively weighted edge or if a specific edge of the
     graph has negative weight.
 
@@ -605,9 +605,13 @@ def negative_weights(G, edge=None):
     ----------
     G : Networkx graph
         A graph
+
     edge : tuple, optional (default=None)
         Checks for a specific edge if it is negatively weighted (not None) or for all
         edges in graph (None) (if one of them is negatively weighted)
+
+    weight: string, optional (default=None)
+        Edge data key corresponding to the edge weight.
 
     Returns
     -------
@@ -641,12 +645,12 @@ def negative_weights(G, edge=None):
             raise nx.NetworkXError('Edge does not exist in given graph.')
         else:
             if weighted_edges(G, edge):
-                if attr['weight'] < 0:
+                if attr[weight] < 0:
                     negative = True
     else:
         for u, v, w in G.edges(data=True):
             if weighted_edges(G, (u, v)):
-                if w['weight'] < 0:
+                if w[weight] < 0:
                     negative = True
     return negative
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -590,3 +590,58 @@ def weighted_edges(G, edge=None):
             if 'weight' not in w:
                 return False
         return weighted
+
+
+def negative_weights(G, edge=None):
+    """Check if the graph has a negatively weighted edge or if a specific edge of the
+    graph has negative weight.
+
+    Parameters
+    ----------
+    G : Networkx graph
+        A graph
+    edge : tuple, optional (default=None)
+        Checks for a specific edge if it is negatively weighted (not None) or for all
+        edges in graph (None) (if one of them is negatively weighted)
+
+    Returns
+    -------
+    Returns True if all graph's edges or a specific edge has negative weight; False
+    otherwise.
+
+    Raises
+    ------
+    NetworkXError
+        If given edge does not exist in graph.
+
+    Examples
+    --------
+    >>> G=nx.Graph()
+    >>> G.add_edges_from([(1, 3), (2, 4), (2, 6)])
+    >>> G.add_edge(1, 2, weight=4)
+    >>> print(nx.negative_weights(G, (1, 2)))
+    False
+    >>> G[2][4]['weight'] = -2
+    >>> print(nx.negative_weights(G))
+    True
+    >>> G = nx.DiGraph()
+    >>> G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -2)])
+    >>> print(nx.negative_weights(G))
+    True
+    """
+    negative = False
+    if edge is not None:
+        attr = G.get_edge_data(*edge)
+        if attr is None:
+            raise nx.NetworkXError('Edge does not exist in given graph.')
+        else:
+            if weighted_edges(G, edge):
+                if attr['weight'] < 0:
+                    negative = True
+    else:
+        for u, v, w in G.edges(data=True):
+            if weighted_edges(G, (u, v)):
+                if w['weight'] < 0:
+                    negative = True
+    return negative
+

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -591,6 +591,10 @@ def is_weighted(G, edge=None, weight='weight'):
             raise nx.NetworkXError(msg)
         return weight in data
 
+    if is_empty(G):
+        # Special handling required since: all([]) == True
+        return False
+
     return all(weight in data for u, v, data in G.edges(data=True))
 
 
@@ -645,3 +649,29 @@ def is_negatively_weighted(G, edge=None, weight='weight'):
 
     return any(weight in data and data[weight] < 0
                for u, v, data in G.edges(data=True))
+
+def is_empty(G):
+    """Returns ``True`` if ``G`` has no edges.
+
+    Parameters
+    ----------
+    G : graph
+        A NetworkX graph.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``G`` has no edges, and ``False`` otherwise.
+
+    Notes
+    -----
+    An empty graph can have nodes but not edges. The empty graph with zero
+    nodes is known as the null graph. This is an O(n) operation where n is the
+    number of nodes in the graph.
+
+    """
+    for node, neighbors in G.adj.items():
+        if neighbors:
+            return False
+    return True
+

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -637,12 +637,6 @@ def negative_weights(G, edge=None, weight='weight'):
         attr = G.get_edge_data(*edge)
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
-        else:
-            if weight in attr:
-                return attr[weight] < 0
+        return weight in attr and attr[weight] < 0
     else:
-        for u, v, w in G.edges(data=True):
-            if weight in w:
-                if w[weight] < 0:
-                    return True
-    return False
+        return any(weight in w and w[weight] < 0 for u, v, w in G.edges(data=True))

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -20,7 +20,7 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'set_node_attributes','get_node_attributes',
            'set_edge_attributes','get_edge_attributes',
            'all_neighbors','non_neighbors', 'non_edges',
-           'common_neighbors']
+           'common_neighbors','weighted_edges']
 
 
 def nodes(G):
@@ -542,3 +542,51 @@ def common_neighbors(G, u, v):
     # Return a generator explicitly instead of yielding so that the above
     # checks are executed eagerly.
     return (w for w in G[u] if w in G[v] and w not in (u, v))
+
+
+def weighted_edges(G, edge=None):
+    """Check if all graph's edges or a specific edge is weighted.
+
+    Parameters
+    ----------
+    G : Networkx graph
+       A graph
+    edge : tuple, optional (default=None)
+        Checks for a specific edge if it is weighted(not None) or for all
+        edges in graph(None)
+
+    Returns
+    -------
+    Returns True if all graph's edges or a specific edge is weighted; False
+    otherwise.
+
+    Raises
+    ------
+    NetworkXError
+        If given edge does not exist in graph.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)
+    >>> print(nx.weighted_edges(G))
+    False
+    >>> print(nx.weighted_edges(G, (2, 3)))
+    False
+    >>> G = nx.DiGraph()
+    >>> G.add_node(1)
+    >>> G.add_node(2)
+    >>> G.add_edge(1, 2, weight=1)
+    >>> print(nx.weighted_edges(G))
+    True
+    """
+    if edge is not None:
+        attr = G.get_edge_data(*edge)
+        if attr is None:
+            raise nx.NetworkXError('Edge does not exist in given graph.')
+        return 'weight' in attr
+    else:
+        weighted = True
+        for u, v, w in G.edges(data=True):
+            if 'weight' not in w:
+                return False
+        return weighted

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -556,7 +556,7 @@ def weighted_edges(G, edge=None, weight='weight'):
         Checks for a specific edge if it is weighted(not None) or for all
         edges in graph(None)
 
-    weight: string, optional (default=None)
+    weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight.
 
     Returns

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -544,16 +544,20 @@ def common_neighbors(G, u, v):
     return (w for w in G[u] if w in G[v] and w not in (u, v))
 
 
-def weighted_edges(G, edge=None):
+def weighted_edges(G, edge=None, weight='weight'):
     """Check if all graph's edges or a specific edge is weighted.
 
     Parameters
     ----------
     G : Networkx graph
        A graph
+
     edge : tuple, optional (default=None)
         Checks for a specific edge if it is weighted(not None) or for all
         edges in graph(None)
+
+    weight: string, optional (default=None)
+       Edge data key corresponding to the edge weight.
 
     Returns
     -------
@@ -568,6 +572,7 @@ def weighted_edges(G, edge=None):
     Examples
     --------
     >>> G = nx.path_graph(4)
+
     >>> print(nx.weighted_edges(G))
     False
     >>> print(nx.weighted_edges(G, (2, 3)))
@@ -583,11 +588,11 @@ def weighted_edges(G, edge=None):
         attr = G.get_edge_data(*edge)
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
-        return 'weight' in attr
+        return weight in attr
     else:
         weighted = True
         for u, v, w in G.edges(data=True):
-            if 'weight' not in w:
+            if weight not in w:
                 return False
         return weighted
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -20,7 +20,7 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'set_node_attributes','get_node_attributes',
            'set_edge_attributes','get_edge_attributes',
            'all_neighbors','non_neighbors', 'non_edges',
-           'common_neighbors','weighted_edges']
+           'common_neighbors','weighted_edges','negative_weights']
 
 
 def nodes(G):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -20,7 +20,7 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'set_node_attributes','get_node_attributes',
            'set_edge_attributes','get_edge_attributes',
            'all_neighbors','non_neighbors', 'non_edges',
-           'common_neighbors','weighted_edges','negative_weights']
+           'common_neighbors', 'is_weighted','negative_weights']
 
 
 def nodes(G):
@@ -544,20 +544,20 @@ def common_neighbors(G, u, v):
     return (w for w in G[u] if w in G[v] and w not in (u, v))
 
 
-def weighted_edges(G, edge=None, weight='weight'):
+def is_weighted(G, edge=None, weight='weight'):
     """Check if all graph's edges or a specific edge is weighted.
 
     Parameters
     ----------
     G : Networkx graph
-       A graph
+        A graph
 
     edge : tuple, optional (default=None)
         Checks for a specific edge if it is weighted(not None) or for all
         edges in graph(None)
 
     weight: string, optional (default='weight')
-       Edge data key corresponding to the edge weight.
+        Edge data key corresponding to the edge weight.
 
     Returns
     -------
@@ -573,15 +573,15 @@ def weighted_edges(G, edge=None, weight='weight'):
     --------
     >>> G = nx.path_graph(4)
 
-    >>> print(nx.weighted_edges(G))
+    >>> print(nx.is_weighted(G))
     False
-    >>> print(nx.weighted_edges(G, (2, 3)))
+    >>> print(nx.is_weighted(G, (2, 3)))
     False
     >>> G = nx.DiGraph()
     >>> G.add_node(1)
     >>> G.add_node(2)
     >>> G.add_edge(1, 2, weight=1)
-    >>> print(nx.weighted_edges(G))
+    >>> print(nx.is_weighted(G))
     True
     """
     if edge is not None:
@@ -589,12 +589,10 @@ def weighted_edges(G, edge=None, weight='weight'):
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
         return weight in attr
-    else:
-        weighted = True
-        for u, v, w in G.edges(data=True):
-            if weight not in w:
-                return False
-        return weighted
+    for u, v, w in G.edges(data=True):
+        if weight not in w:
+            return False
+    return True
 
 
 def negative_weights(G, edge=None, weight='weight'):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -653,4 +653,3 @@ def negative_weights(G, edge=None, weight='weight'):
                 if w[weight] < 0:
                     negative = True
     return negative
-

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -20,7 +20,8 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'set_node_attributes','get_node_attributes',
            'set_edge_attributes','get_edge_attributes',
            'all_neighbors','non_neighbors', 'non_edges',
-           'common_neighbors', 'is_weighted','negative_weights']
+           'common_neighbors', 'is_weighted','is_negatively_weighted',
+           'is_empty']
 
 
 def nodes(G):
@@ -545,97 +546,102 @@ def common_neighbors(G, u, v):
 
 
 def is_weighted(G, edge=None, weight='weight'):
-    """Check if all graph's edges or a specific edge is weighted.
+    """Returns ``True`` if ``G`` has weighted edges.
 
     Parameters
     ----------
-    G : Networkx graph
-        A graph
+    G : graph
+        A NetworkX graph.
 
-    edge : tuple, optional (default=None)
-        Checks for a specific edge if it is weighted(not None) or for all
-        edges in graph(None)
+    edge : tuple, optional
+        A 2-tuple specifying the only edge in ``G`` that will be tested. If
+        ``None``, then every edge in ``G`` is tested.
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight.
+    weight: string, optional
+        The attribute name used to query for edge weights.
 
     Returns
     -------
-    Returns True if all graph's edges or a specific edge is weighted; False
-    otherwise.
+    bool
+        A boolean signifying if ``G``, or the specified edge, is weighted.
 
     Raises
     ------
     NetworkXError
-        If given edge does not exist in graph.
+        If the specified edge does not exist.
 
     Examples
     --------
     >>> G = nx.path_graph(4)
+    >>> nx.is_weighted(G)
+    False
+    >>> nx.is_weighted(G, (2, 3))
+    False
 
-    >>> print(nx.is_weighted(G))
-    False
-    >>> print(nx.is_weighted(G, (2, 3)))
-    False
     >>> G = nx.DiGraph()
-    >>> G.add_node(1)
-    >>> G.add_node(2)
     >>> G.add_edge(1, 2, weight=1)
-    >>> print(nx.is_weighted(G))
+    >>> nx.is_weighted(G)
     True
+
     """
     if edge is not None:
-        attr = G.get_edge_data(*edge)
-        if attr is None:
-            raise nx.NetworkXError('Edge does not exist in given graph.')
-        return weight in attr
-    return all(weight in w for u, v, w in G.edges(data=True))
+        data = G.get_edge_data(*edge)
+        if data is None:
+            msg = 'Edge {!r} does not exist.'.format(edge)
+            raise nx.NetworkXError(msg)
+        return weight in data
+
+    return all(weight in data for u, v, data in G.edges(data=True))
 
 
-def negative_weights(G, edge=None, weight='weight'):
-    """Check if the graph has a negatively weighted edge or if a specific edge of the
-    graph has negative weight.
+def is_negatively_weighted(G, edge=None, weight='weight'):
+    """Returns ``True`` if ``G`` has negatively weighted edges.
 
     Parameters
     ----------
-    G : Networkx graph
-        A graph
+    G : graph
+        A NetworkX graph.
 
-    edge : tuple, optional (default=None)
-        Checks for a specific edge if it is negatively weighted (not None) or for all
-        edges in graph (None) (if one of them is negatively weighted)
+    edge : tuple, optional
+        A 2-tuple specifying the only edge in ``G`` that will be tested. If
+        ``None``, then every edge in ``G`` is tested.
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight.
+    weight: string, optional
+        The attribute name used to query for edge weights.
 
     Returns
     -------
-    Returns True if all graph's edges or a specific edge has negative weight; False
-    otherwise.
+    bool
+        A boolean signifying if ``G``, or the specified edge, is negatively
+        weighted.
 
     Raises
     ------
     NetworkXError
-        If given edge does not exist in graph.
+        If the specified edge does not exist.
 
     Examples
     --------
     >>> G=nx.Graph()
     >>> G.add_edges_from([(1, 3), (2, 4), (2, 6)])
     >>> G.add_edge(1, 2, weight=4)
-    >>> print(nx.negative_weights(G, (1, 2)))
+    >>> nx.is_negatively_weighted(G, (1, 2)))
     False
     >>> G[2][4]['weight'] = -2
-    >>> print(nx.negative_weights(G))
+    >>> nx.negatively_weighted(G)
     True
     >>> G = nx.DiGraph()
     >>> G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -2)])
-    >>> print(nx.negative_weights(G))
+    >>> nx.is_negatively_weighted(G)
     True
+
     """
     if edge is not None:
-        attr = G.get_edge_data(*edge)
-        if attr is None:
-            raise nx.NetworkXError('Edge does not exist in given graph.')
-        return weight in attr and attr[weight] < 0
-    return any(weight in w and w[weight] < 0 for u, v, w in G.edges(data=True))
+        data = G.get_edge_data(*edge)
+        if data is None:
+            msg = 'Edge {!r} does not exist.'.format(edge)
+            raise nx.NetworkXError(msg)
+        return weight in data and data[weight] < 0
+
+    return any(weight in data and data[weight] < 0
+               for u, v, data in G.edges(data=True))

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -644,12 +644,11 @@ def negative_weights(G, edge=None, weight='weight'):
         if attr is None:
             raise nx.NetworkXError('Edge does not exist in given graph.')
         else:
-            if weighted_edges(G, edge):
-                if attr[weight] < 0:
-                    negative = True
+            if weight in attr:
+                return attr[weight] < 0
     else:
         for u, v, w in G.edges(data=True):
-            if weighted_edges(G, (u, v)):
+            if weight in w:
                 if w[weight] < 0:
                     negative = True
     return negative

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -234,7 +234,7 @@ class TestFunction(object):
         assert_raises(nx.NetworkXError, nx.weighted_edges, G, (1, 2))
 
     def test_negative_weights(self):
-        G=nx.Graph()
+        G = nx.Graph()
         G.add_node(1)
         G.add_nodes_from([2, 3, 4, 5])
         assert_false(nx.negative_weights(G))

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -216,22 +216,22 @@ class TestFunction(object):
 
     def test_weighted_edges(self):
         G = nx.path_graph(4)
-        assert_false(nx.weighted_edges(G))
-        assert_false(nx.weighted_edges(G, (2, 3)))
+        assert_false(nx.is_weighted(G))
+        assert_false(nx.is_weighted(G, (2, 3)))
         G.add_node(4)
         G.add_edge(3, 4, weight=4)
-        assert_false(nx.weighted_edges(G))
-        assert_true(nx.weighted_edges(G, (3, 4)))
+        assert_false(nx.is_weighted(G))
+        assert_true(nx.is_weighted(G, (3, 4)))
         G = nx.DiGraph()
         G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
                                      ('0', '2', 2), ('1', '2', 4),
                                      ('2', '3', 1)])
-        assert_true(nx.weighted_edges(G))
-        assert_true(nx.weighted_edges(G, ('1', '0')))
+        assert_true(nx.is_weighted(G))
+        assert_true(nx.is_weighted(G, ('1', '0')))
         G = G.to_undirected()
-        assert_true(nx.weighted_edges(G))
-        assert_true(nx.weighted_edges(G, ('1', '0')))
-        assert_raises(nx.NetworkXError, nx.weighted_edges, G, (1, 2))
+        assert_true(nx.is_weighted(G))
+        assert_true(nx.is_weighted(G, ('1', '0')))
+        assert_raises(nx.NetworkXError, nx.is_weighted, G, (1, 2))
 
     def test_negative_weights(self):
         G = nx.Graph()

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -214,46 +214,61 @@ class TestFunction(object):
         for e in expected:
             assert_true(e in nedges)
 
-    def test_weighted_edges(self):
+    def test_is_weighted(self):
+        G = nx.Graph()
+        assert_false(nx.is_weighted(G))
+
         G = nx.path_graph(4)
         assert_false(nx.is_weighted(G))
         assert_false(nx.is_weighted(G, (2, 3)))
+
         G.add_node(4)
         G.add_edge(3, 4, weight=4)
         assert_false(nx.is_weighted(G))
         assert_true(nx.is_weighted(G, (3, 4)))
+
         G = nx.DiGraph()
         G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
                                      ('0', '2', 2), ('1', '2', 4),
                                      ('2', '3', 1)])
         assert_true(nx.is_weighted(G))
         assert_true(nx.is_weighted(G, ('1', '0')))
+
         G = G.to_undirected()
         assert_true(nx.is_weighted(G))
         assert_true(nx.is_weighted(G, ('1', '0')))
+
         assert_raises(nx.NetworkXError, nx.is_weighted, G, (1, 2))
 
-    def test_negative_weights(self):
+    def test_is_negatively_weighted(self):
         G = nx.Graph()
+        assert_false(nx.is_negatively_weighted(G))
+
         G.add_node(1)
         G.add_nodes_from([2, 3, 4, 5])
-        assert_false(nx.negative_weights(G))
+        assert_false(nx.is_negatively_weighted(G))
+
         G.add_edge(1, 2, weight=4)
-        assert_false(nx.negative_weights(G, (1, 2)))
+        assert_false(nx.is_negatively_weighted(G, (1, 2)))
+
         G.add_edges_from([(1, 3), (2, 4), (2, 6)])
         G[1][3]['color'] = 'blue'
-        assert_false(nx.negative_weights(G))
-        assert_false(nx.negative_weights(G, (1, 3)))
+        assert_false(nx.is_negatively_weighted(G))
+        assert_false(nx.is_negatively_weighted(G, (1, 3)))
+
         G[2][4]['weight'] = -2
-        assert_true(nx.negative_weights(G, (2, 4)))
-        assert_true(nx.negative_weights(G))
+        assert_true(nx.is_negatively_weighted(G, (2, 4)))
+        assert_true(nx.is_negatively_weighted(G))
+
         G = nx.DiGraph()
         G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -2),
                                    ('0', '2', 2), ('1', '2', -3), ('2', '3', 1)])
-        assert_true(nx.negative_weights(G))
-        assert_false(nx.negative_weights(G, ('0', '3')))
-        assert_true(nx.negative_weights(G, ('1', '0')))
-        assert_raises(nx.NetworkXError, nx.negative_weights, G, (1, 4))
+        assert_true(nx.is_negatively_weighted(G))
+        assert_false(nx.is_negatively_weighted(G, ('0', '3')))
+        assert_true(nx.is_negatively_weighted(G, ('1', '0')))
+
+        assert_raises(nx.NetworkXError, nx.is_negatively_weighted, G, (1, 4))
+
 
 class TestCommonNeighbors():
     def setUp(self):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -214,6 +214,25 @@ class TestFunction(object):
         for e in expected:
             assert_true(e in nedges)
 
+    def test_weighted_edges(self):
+        G = nx.path_graph(4)
+        assert_false(nx.weighted_edges(G))
+        assert_false(nx.weighted_edges(G, (2, 3)))
+        G.add_node(4)
+        G.add_edge(3, 4, weight=4)
+        assert_false(nx.weighted_edges(G))
+        assert_true(nx.weighted_edges(G, (3, 4)))
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
+                                     ('0', '2', 2), ('1', '2', 4),
+                                     ('2', '3', 1)])
+        assert_true(nx.weighted_edges(G))
+        assert_true(nx.weighted_edges(G, ('1', '0')))
+        G = G.to_undirected()
+        assert_true(nx.weighted_edges(G))
+        assert_true(nx.weighted_edges(G, ('1', '0')))
+        assert_raises(nx.NetworkXError, nx.weighted_edges, G, (1, 2))
+
 
 class TestCommonNeighbors():
     def setUp(self):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -233,6 +233,27 @@ class TestFunction(object):
         assert_true(nx.weighted_edges(G, ('1', '0')))
         assert_raises(nx.NetworkXError, nx.weighted_edges, G, (1, 2))
 
+    def test_negative_weights(self):
+        G=nx.Graph()
+        G.add_node(1)
+        G.add_nodes_from([2, 3, 4, 5])
+        assert_false(nx.negative_weights(G))
+        G.add_edge(1, 2, weight=4)
+        assert_false(nx.negative_weights(G, (1, 2)))
+        G.add_edges_from([(1, 3), (2, 4), (2, 6)])
+        G[1][3]['color'] = 'blue'
+        assert_false(nx.negative_weights(G))
+        assert_false(nx.negative_weights(G, (1, 3)))
+        G[2][4]['weight'] = -2
+        assert_true(nx.negative_weights(G, (2, 4)))
+        assert_true(nx.negative_weights(G))
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -2),
+                                   ('0', '2', 2), ('1', '2', -3), ('2', '3', 1)])
+        assert_true(nx.negative_weights(G))
+        assert_false(nx.negative_weights(G, ('0', '3')))
+        assert_true(nx.negative_weights(G, ('1', '0')))
+        assert_raises(nx.NetworkXError, nx.negative_weights, G, (1, 4))
 
 class TestCommonNeighbors():
     def setUp(self):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -404,3 +404,12 @@ def test_get_edge_attributes():
             keys = [(0,1), (1,2)]
         for key in keys:
             assert_equal(attrs[key], 100)
+
+def test_is_empty():
+    graphs = [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
+    for G in graphs:
+        assert_true(nx.is_empty(G))
+        G.add_nodes_from(range(5))
+        assert_true(nx.is_empty(G))
+        G.add_edges_from([(1, 2), (3, 4)])
+        assert_false(nx.is_empty(G))


### PR DESCRIPTION
Renames `negative_weights` to `is_negatively_weighted` to be consistent with `is_weighted`. Some docstring updates. Finally, add coverage for the empty graph---this also adds an `is_empty` function.
